### PR TITLE
fix crash on pulseaudio

### DIFF
--- a/src/patchbay.cpp
+++ b/src/patchbay.cpp
@@ -1,4 +1,5 @@
 #include "patchbay.impl.hpp"
+#include <dlfcn.h>
 
 namespace vencord
 {
@@ -28,6 +29,13 @@ namespace vencord
 
         if (!instance)
         {
+            auto handle = dlopen("libpipewire-0.3.so", RTLD_LAZY);
+            if (!handle)
+            {
+                throw std::runtime_error("libpipewire is not available");
+            }
+            dlclose(handle);
+
             instance = std::unique_ptr<patchbay>(new patchbay);
         }
 


### PR DESCRIPTION
the current implementation segfaults on pulseaudio because it tries to call pipewire methods, which, for obvious reason, are not actually available:
```
Message: Process 486613 (electron) of user 1000 dumped core.
         
         Stack trace of thread 487173:
         #0  0x00007f4aa36f9404 pw_proxy_get_bound_id (libpipewire-0.3.so.0 + 0x78404)
         #1  0x00007f4aa37a0fc8 n/a (/tmp/misc/Vesktop/static/dist/venmic.node + 0x3cfc8)
         ELF object binary architecture: AMD x86-64
```

this pr fixes it by first manually dlopening libpipewire to check if it's installed

i don't know if this is the best method to do so, so feel free to close this pr if there's a better method 